### PR TITLE
.fix(video): prevent width overflow

### DIFF
--- a/heti.css
+++ b/heti.css
@@ -465,6 +465,11 @@ body iframe,
   height: 100%;
 }
 
+body video,
+.feed_article video {
+  max-width: 100%;
+}
+
 body img,
 .feed_article img {
   max-width: 100%;

--- a/lib/heti.scss
+++ b/lib/heti.scss
@@ -74,6 +74,10 @@ $rss-prefix: '.feed';
     height: 100%;
   }
 
+  video {
+    max-width: 100%;
+  }
+
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
Some article with video like [block-links-are-a-pain-and-maybe-just-a-bad-idea](https://css-tricks.com/block-links-are-a-pain-and-maybe-just-a-bad-idea/), video tag will be overflow.